### PR TITLE
Resolve missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5==5.15.11
 PyQt5_sip==12.15.0
+requests==2.32.3


### PR DESCRIPTION
Running arch linux, with python inside venv. Without this patch, when trying to run `python app.py`, you get the following error:
```python
  File "/git/AnimeWwise/app.py", line 7, in <module>
    from requests import get
ModuleNotFoundError: No module named 'requests'
```

This pr simply adds requests to the requirements.txt file

If I can figure out python, I'll later be submitting a pr to run the exe files via wine on linux. Can verify app works entirely as expected when adding "wine" to all the commands (and removing usage of `os.startfile`, its not technically needed)