### PR TITLE
Add "Retain folder structure" toggle for extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,7 @@ class BackgroundWorker(QObject):
 			self.files = data["files"]
 			self.format = data["format"]
 			self.output = data["output"]
+			self.retain_structure = data.get("retain_structure", False)
 
 	def run(self):
 		if self.action == "load":
@@ -69,7 +70,7 @@ class BackgroundWorker(QObject):
 				self.finished.emit({"action": "error", "content": {"msg": "Nothing selected !", "state": 2}})
 				return
 			print(f"Extracting {len(self.files)} files...")
-			self.extract.extract_files(self.input, self.files, self.output, self.format, progress=self.progress.emit)
+			self.extract.extract_files(self.input, self.files, self.output, self.format, self.retain_structure, progress=self.progress.emit)
 			self.finished.emit({"action": "extract"})
 
 class UpdaterWorker(QObject):
@@ -528,7 +529,7 @@ class AnimeWwise(QMainWindow):
 
 		# yet another block of threading bs
 		self.backgroundThread = QThread()
-		self.backgroundWorker = BackgroundWorker("extract", self.extract, {"input": self.currentInput, "files": checked_items, "format": self.format, "output": self.folders["output"]})
+		self.backgroundWorker = BackgroundWorker("extract", self.extract, {"input": self.currentInput, "files": checked_items, "format": self.format, "output": self.folders["output"], "retain_structure": self.actionRetain_folder_structure.isChecked()})
 		self.backgroundWorker.moveToThread(self.backgroundThread)
 		self.backgroundThread.started.connect(self.backgroundWorker.run)
 		self.backgroundWorker.finished.connect(self.handleFinished)

--- a/extract.py
+++ b/extract.py
@@ -251,7 +251,7 @@ class WwiseExtract:
 
 	### extracting files ###
 
-	def extract_files(self, _input, files, output, _format, progress):
+	def extract_files(self, _input, files, output, _format, retain_structure=False, progress=None):
 		temp_dir = tempfile.TemporaryDirectory()
 		self.progress = progress
 		self.steps = {
@@ -267,7 +267,7 @@ class WwiseExtract:
 		else:
 			output_folder = path(temp_dir.name, "wem")
 
-		self.extract_wem(_input, files, output_folder)
+		self.extract_wem(_input, files, output_folder, retain_structure)
 
 		if _format == "wem":
 			temp_dir.cleanup()
@@ -275,7 +275,10 @@ class WwiseExtract:
 
 		# wav
 		new_input = output_folder
-		files = [path("/".join(file["path"]), file["name"]) for file in files]
+		if retain_structure:
+			files = [path(os.path.dirname(file["source"]), "/".join(file["path"]), file["name"]) for file in files]
+		else:
+			files = [path("/".join(file["path"]), file["name"]) for file in files]
 
 		if _format == "wav":
 			output_folder = output
@@ -298,7 +301,7 @@ class WwiseExtract:
 		temp_dir.cleanup()
 		return
 
-	def extract_wem(self, _input, files, output):
+	def extract_wem(self, _input, files, output, retain_structure=False):
 		print(": Extracting audio as wem")
 		all_sources = list(set([e["source"] for e in files]))
 
@@ -339,6 +342,9 @@ class WwiseExtract:
 						continue
 							
 				filepath = path("/".join(file["path"]), file["name"])
+				if retain_structure:
+					source_dir = os.path.dirname(file["source"])
+					filepath = path(source_dir, filepath)
 				fullpath = path(output, filepath)
 				os.makedirs(os.path.dirname(fullpath), exist_ok=True)
 				

--- a/extract.py
+++ b/extract.py
@@ -276,7 +276,7 @@ class WwiseExtract:
 		# wav
 		new_input = output_folder
 		if retain_structure:
-			files = [path(os.path.dirname(file["source"]), "/".join(file["path"]), file["name"]) for file in files]
+			files = [path(file["source"], "/".join(file["path"]), file["name"]) for file in files]
 		else:
 			files = [path("/".join(file["path"]), file["name"]) for file in files]
 
@@ -343,8 +343,7 @@ class WwiseExtract:
 							
 				filepath = path("/".join(file["path"]), file["name"])
 				if retain_structure:
-					source_dir = os.path.dirname(file["source"])
-					filepath = path(source_dir, filepath)
+					filepath = path(file["source"], filepath)
 				fullpath = path(output, filepath)
 				os.makedirs(os.path.dirname(fullpath), exist_ok=True)
 				

--- a/gui.ui
+++ b/gui.ui
@@ -472,6 +472,8 @@ Subfolders are disabled in this mode, make sure to be in the correct place. For 
     </widget>
     <addaction name="menuOutput_format"/>
     <addaction name="separator"/>
+    <addaction name="actionRetain_folder_structure"/>
+    <addaction name="separator"/>
     <addaction name="actionExtract_All"/>
     <addaction name="actionExtract_Selected"/>
    </widget>
@@ -560,6 +562,17 @@ Subfolders are disabled in this mode, make sure to be in the correct place. For 
    </property>
    <property name="visible">
     <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionRetain_folder_structure">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Retain folder structure</string>
    </property>
   </action>
   <action name="actionExpand_all">


### PR DESCRIPTION
# Claude Opus 4.6 was used for this pull request

This PR adds a new "Retain folder structure" toggle to the Extract menu. When enabled, extracting audio files will recreate the original source's directory structure and include the source `.pck` file name as a folder in the output directory.

Previously, all extracted audio files were placed directly into the selected output directory (or nested solely based on their mapped paths). This could lead to a disorganized output folder, especially since multiple audio streams from different archives could end up mixed together. 

By retaining the folder structure and including the source `.pck` name, users can easily determine which archive each audio file originated from (e.g., `<output_folder>/subfolder/SoundBank_SFX_0.pck/mapped_name.wem`), making it significantly easier to manage and sort extracted assets.

### Changes
* **UI (`gui.ui`)**: Added a checkable `actionRetain_folder_structure` item to the Extract menu, positioned between the output format options and the extract actions.
* **App Logic (`app.py`)**: Updated the extraction process to read the toggle's state and pass the `retain_structure` flag to the background extraction worker.
* **Extraction (`extract.py`)**: 
  * Updated `extract_wem` to prepend `file["source"]` (the relative path including the `.pck` filename) to the extraction path when `retain_structure` is True.
  * Updated `extract_files` to ensure the correct path structure is propagated to downstream conversion steps (wav, mp3, ogg).